### PR TITLE
Lock to @solana/web3.js 1.x for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ bun run dev
 ## Install dependencies for solana wallet adapter
 
 ```sh
-bun add @solana/wallet-adapter-base @solana/wallet-adapter-react @solana/wallet-adapter-react-ui @solana/wallet-adapter-wallets @solana/web3.js
+bun add @solana/wallet-adapter-base @solana/wallet-adapter-react @solana/wallet-adapter-react-ui @solana/wallet-adapter-wallets @solana/web3.js@1
 ```
 
 ## Todos


### PR DESCRIPTION

Read why, here: https://github.com/solana-labs/solana-web3.js/issues/3498